### PR TITLE
Infer example types

### DIFF
--- a/app/dociql/generate-example.js
+++ b/app/dociql/generate-example.js
@@ -48,9 +48,6 @@ function generateQueryInternal(field, expandGraph, arguments, depth, typeCounts 
 
         if (depth > 1) {
             const typeKey = `${field.name}->${returnType.name}`;
-            if (typeCounts.includes(typeKey)) {
-                subQuery = space + "  ...Recursive" + returnType.name + "Fragment\n"
-            }
             typeCounts.push(typeKey)
         }
 
@@ -61,7 +58,7 @@ function generateQueryInternal(field, expandGraph, arguments, depth, typeCounts 
 
         keys = toSelect ? keys.filter(key => toSelect.includes(key) || toExpand.includes(key)) : keys;
 
-        subQuery = subQuery || keys.map(key => {
+        subQuery = keys.map(key => {
             return generateQueryInternal(
                 childFields[key],
                 expandGraph,

--- a/app/helpers/exampleFromDescription.js
+++ b/app/helpers/exampleFromDescription.js
@@ -7,7 +7,17 @@ module.exports = function(description) {
     let example = null;
     if (description !== null) {
         const match = description.match(/@example:?[\s]*([^\n]*)/);
-        example = match !== null ? match[1] : example;
+        if (match !== null) {
+            try {
+                example = JSON.parse(String(match[1]));
+            } catch (e) {
+                console.log(
+                    '\x1b[43m\x1b[30m[WARNING]',
+                    `\`${match[1]}\` is not a valid example. If it's a string, make sure it is surrounded by quotation marks \`"\`.`,
+                    '\x1b[0m'
+                )
+            }
+        }
     }
 
     return example;


### PR DESCRIPTION
* Infer example types
* Remove `...Recursive` fragments in query examples . Using explicit fields instead.